### PR TITLE
Fix fakku page # issue

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -57,19 +57,20 @@ function prepUploadOperation(message, list, row) {
 			return;
 		}
 
-
-		for (let x = 0; x < 3; x++) {
-			try {
-				row.page = await pFetch(row.link);
-				if (row.page == -1) continue;
-				break;
-			} catch (e) {
-				await new Promise((resolve, reject) => setTimeout(resolve, 500));
+		if (row.page === -1) {
+			for (let x = 0; x < 3; x++) {
+				try {
+					row.page = await pFetch(row.link);
+					if (row.page == -1) continue;
+					break;
+				} catch (e) {
+					await new Promise((resolve, reject) => setTimeout(resolve, 500));
+				}
 			}
-		}
-		if (row.page == -1) {
-			message.channel.send('Failed to get page numbers! Please set it manually with `-pg`.');
-			return;
+			if (row.page == -1) {
+				message.channel.send('Failed to get page numbers! Please set it manually with `-pg`.');
+				return;
+			}
 		}
 
 		row.uid = uuidv4()


### PR DESCRIPTION
sriracha always overrides the page field when pushing a row to list 4 or 9, which can cause problems for a fakku entry without a page number. this changes it so that if the page number is manually set, the page fetch will not occur. 