### PR TITLE
Indentation, Fixups and Parody Improvements

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -18,7 +18,7 @@ const decode = require('html-entities').decode;
 const JSSoup = require('jssoup').default;
 
 const underageCharacters = require('../config/underage.json');
-const fixParodies = require('../config/badparodies.json');
+const renameParodies = require('../config/parodies.json');
 
 /**
  * Secondhand function to accept flag object.
@@ -305,10 +305,10 @@ function setInfo(message, list, row) {
 				if (!row.parody) {
 					if (parodies.length >= 1) {
 						row.parody = parodies.join(", ");
-						for (let p = 0; p < fixParodies.length; p++) {
-							for (let s = 0; s < fixParodies[p].oldname.length; s++) {
-								if (row.parody == fixParodies[p].oldname[s]) {
-									row.parody = fixParodies[p].newname;
+						for (let p = 0; p < renameParodies.length; p++) {
+							for (let s = 0; s < renameParodies[p].oldname.length; s++) {
+								if (row.parody == renameParodies[p].oldname[s]) {
+									row.parody = renameParodies[p].newname;
 								}
 							}
 						}

--- a/commands/add.js
+++ b/commands/add.js
@@ -173,7 +173,7 @@ function prepUploadOperation(message, list, row) {
  */
 function setInfo(message, list, row) {
 	return new Promise(async (resolve, reject) => {
-		if (row.link.match(/nhentai|fakku|e-hentai/) !== null && (!row.parody || !row.author || !row.title)) {
+		if (row.link.match(/nhentai|fakku|e-hentai/) !== null && (list != 4 && list != 9) && (!row.parody || !row.author || !row.title)) {
 			try {
 				let title = '';
 				let author = '';
@@ -304,14 +304,17 @@ function setInfo(message, list, row) {
 				}
 				if (!row.parody) {
 					if (parodies.length >= 1) {
-						row.parody = parodies.join(", ");
-						for (let p = 0; p < renameParodies.length; p++) {
-							for (let s = 0; s < renameParodies[p].oldname.length; s++) {
-								if (row.parody == renameParodies[p].oldname[s]) {
-									row.parody = renameParodies[p].newname;
+						for (let u = 0; u < parodies.length; u++) {
+							for (let p = 0; p < renameParodies.length; p++) {
+								for (let s = 0; s < renameParodies[p].oldname.length; s++) {
+									if (parodies[u] == renameParodies[p].oldname[s]) {
+											parodies[u] = renameParodies[p].newname;
+									}
 								}
 							}
 						}
+						let newParodies = [...new Set(parodies)];
+						row.parody = newParodies.join(", ");
 						message.channel.send(`Updated missing parody \`${row.parody}\`!`);
 					} else {
 						message.channel.send(`No parodies detected.`);

--- a/commands/add.js
+++ b/commands/add.js
@@ -305,11 +305,10 @@ function setInfo(message, list, row) {
 				if (!row.parody) {
 					if (parodies.length >= 1) {
 						for (let u = 0; u < parodies.length; u++) {
-							for (let p = 0; p < renameParodies.length; p++) {
-								for (let s = 0; s < renameParodies[p].oldname.length; s++) {
-									if (parodies[u] == renameParodies[p].oldname[s]) {
-											parodies[u] = renameParodies[p].newname;
-									}
+							for (const [key, value] of Object.entries(renameParodies)) {
+								if (`${value}`.includes(parodies[u])) {
+									parodies[u] = `${key}`;
+									break;
 								}
 							}
 						}

--- a/commands/move.js
+++ b/commands/move.js
@@ -29,7 +29,6 @@ async function move(message, list, ID, dest) {
 		let data = new Row(rows[ID - 1]);
 
 		return await add.add(message, dest, data).then((resp) => {
-			console.log(resp);
 			if(resp) { return del(message, list, ID); };
 		});
 	} catch (e) {


### PR DESCRIPTION
* Minor changes to the indentation to keep it consistent and readable
* Readds link check to avoid a minor issue with Imgur links (it would try to set the author, title and parody and fail). Also add a list check to avoid updating the fields when moving an entry to list 4 or 9 (since the entry should already have the necessary information). See Line 176
* Remove "Series" from parodies pulled from FAKKU, since certain franchises like Fate are listed as "Fate Series" on their site. See Line 256
* Filter "Original Work" from parodies pulled from FAKKU. See Line 258
* Remove exhentai from match function since it will always fail (can't access the site without an account). See Line 259
* Add a filter for certain parodies. We use the franchise name for some series (e.g. "Fate" instead of "Fate Grand Order"), so now it will check if the parody name is in parodies.json, and if it finds a match, it will replace it with the preferred name. If there's multiple parodies, we create a set to delete duplicated entries, and then a new array (line 316).
* Try to fix a bug when checking the HTTP status code. See Line 364
* Remove console.log that Sting added while trying to fix a bug

All these changes (besides the status code one, since Cloudflare is disabled at the moment) were tested multiple times by adding works from 4 different sites to the lists. I also tested works with multiple parodies that would result in a duplicated value and the filter worked as expected.

Once the PR is merged, it will require a parody.json file in the config folder. I have attached said file here: [parodies.zip](https://github.com/crispy-whiskers/sriracha/files/8886570/parodies.zip)

Edit 1: Fixed parodies.json

