### PR TITLE
Continue e-h migration

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -100,7 +100,7 @@ function prepUploadOperation(message, list, row) {
 		}
 
 		if (!row.uid) {
-			row.uid = uuidv4()
+			row.uid = uuidv4();
 		}
 
 		// Chop off trailing slashes in the links

--- a/commands/add.js
+++ b/commands/add.js
@@ -33,19 +33,19 @@ async function flagAdd(message, flags) {
 	}
 
 	if(flags.hasOwnProperty('l')) {
-	flags.l = flags.l.replace('http://', 'https://');
+		flags.l = flags.l.replace('http://', 'https://');
 	}
 	if(flags.hasOwnProperty('l1')) {
-	flags.l1 = flags.l1.replace('http://', 'https://');
+		flags.l1 = flags.l1.replace('http://', 'https://');
 	}
 	if(flags.hasOwnProperty('l2')) {
-	flags.l2 = flags.l2.replace('http://', 'https://');
+		flags.l2 = flags.l2.replace('http://', 'https://');
 	}
 	if(flags.hasOwnProperty('l3')) {
-	flags.l3 = flags.l3.replace('http://', 'https://');
+		flags.l3 = flags.l3.replace('http://', 'https://');
 	}
 	if(flags.hasOwnProperty('l4')) {
-	flags.l4 = flags.l4.replace('http://', 'https://');
+		flags.l4 = flags.l4.replace('http://', 'https://');
 	}
 
 	if (flags.atag) {
@@ -105,16 +105,16 @@ function prepUploadOperation(message, list, row) {
 
 		// Chop off trailing slashes in the links
 		if (row.hm) {
-		row.hm = row.hm.replace(/\/$/, "");
+			row.hm = row.hm.replace(/\/$/, "");
 		}
 		if (row.nh) {
-		row.nh = row.nh.replace(/\/$/, "");
+			row.nh = row.nh.replace(/\/$/, "");
 		}
 		if (row.eh) {
-		row.eh = row.eh.replace(/\/$/, "");
+			row.eh = row.eh.replace(/\/$/, "");
 		}
 		if (row.im) {
-		row.im = row.im.replace(/\/$/, "");
+			row.im = row.im.replace(/\/$/, "");
 		}
 
 		// Chop off any mobile imgur links

--- a/commands/add.js
+++ b/commands/add.js
@@ -32,19 +32,45 @@ async function flagAdd(message, flags) {
 		return false;
 	}
 
-	if(flags.hasOwnProperty('l')) {
+	if (flags.hasOwnProperty('l')) {
 		flags.l = flags.l.replace('http://', 'https://');
+		let site = flags.l.match(/hmarket|nhentai|e-hentai|imgur|fakku|irodoricomics|ebookrenta/)[0];
+		switch (site) {
+			case 'hmarket':
+				flags.l1 = flags.l;
+				delete flags.l;
+				break;
+			case 'nhentai':
+			case 'fakku':
+			case 'irodoricomics':
+			case 'ebookrenta':
+				flags.l2 = flags.l;
+				delete flags.l;
+				break;
+			case 'e-hentai':
+				flags.l3 = flags.l;
+				delete flags.l;
+				break;
+			case 'imgur':
+				flags.l4 = flags.l;
+				delete flags.l; 
+				break;
+			default:
+				message.channel.send('Link from unsupported site detected! Please try to only use links from Hmarket, nhentai, E-hentai, Imgur, FAKKU, Idodori, or Renta!');
+				console.log('Link from unsupported site! This should never happen');
+				break;
+		}
 	}
-	if(flags.hasOwnProperty('l1')) {
+	if (flags.hasOwnProperty('l1')) {
 		flags.l1 = flags.l1.replace('http://', 'https://');
 	}
-	if(flags.hasOwnProperty('l2')) {
+	if (flags.hasOwnProperty('l2')) {
 		flags.l2 = flags.l2.replace('http://', 'https://');
 	}
-	if(flags.hasOwnProperty('l3')) {
+	if (flags.hasOwnProperty('l3')) {
 		flags.l3 = flags.l3.replace('http://', 'https://');
 	}
-	if(flags.hasOwnProperty('l4')) {
+	if (flags.hasOwnProperty('l4')) {
 		flags.l4 = flags.l4.replace('http://', 'https://');
 	}
 
@@ -149,6 +175,13 @@ function prepUploadOperation(message, list, row) {
 					
 			const data = response.gmetadata[0];		
 			imageLocation = data.thumb;
+		} else if (row?.im?.match(/imgur/)) {
+			let hashCode = /https:\/\/imgur.com\/a\/([A-z0-9]*)/.exec(row.im)[1];
+			//extract identification part from the link
+			let resp = await axios.get(`https://api.imgur.com/3/album/${hashCode}/images`, {
+				headers: { Authorization: info.imgurClient },
+			})
+			imageLocation = resp.data.data[0].link;
 		} else if (row?.nh?.match(/nhentai\.net\/g\/\d{1,6}\/\d+/)) {
 			let resp = (await axios.get(row.nh)).data.match(/(?<link>https:\/\/i\.nhentai\.net\/galleries\/\d+\/\d+\..{3})/);
 			if (typeof resp?.groups?.link === 'undefined') {
@@ -166,13 +199,6 @@ function prepUploadOperation(message, list, row) {
 				return;
 			}
 			imageLocation = resp.groups.link;
-		} else if (row?.im?.match(/imgur/)) {
-			let hashCode = /https:\/\/imgur.com\/a\/([A-z0-9]*)/.exec(row.im)[1];
-			//extract identification part from the link
-			let resp = await axios.get(`https://api.imgur.com/3/album/${hashCode}/images`, {
-				headers: { Authorization: info.imgurClient },
-			})
-			imageLocation = resp.data.data[0].link;
 		} else if (row?.nh?.match(/fakku\.net/)) {
 			let resp = (await axios.get(row.nh).catch((e) => {
 				console.log("Uh oh stinky");

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -28,7 +28,8 @@ async function del(message, list, ID) {
 		log.log("Deleted `" + JSON.stringify(new Row(rows[ID - 1])) + "`");
 
 		let target = new Row(rows[ID - 1])
-		const link = target?.nh;
+		
+		let link = target?.hm ?? target?.nh ?? target?.eh ?? target?.im;
 
 		await sheets.delete(name, ID);
 		message.channel.send(`Successfully deleted \`${list}#${ID} ${'(' + link + ')' ?? ''}\`!`);

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -28,8 +28,7 @@ async function del(message, list, ID) {
 		log.log("Deleted `" + JSON.stringify(new Row(rows[ID - 1])) + "`");
 
 		let target = new Row(rows[ID - 1])
-		
-		let link = target?.hm ?? target?.nh ?? target?.eh ?? target?.im;
+		const link = target?.hm ?? target?.nh ?? target?.eh ?? target?.im;
 
 		await sheets.delete(name, ID);
 		message.channel.send(`Successfully deleted \`${list}#${ID} ${'(' + link + ')' ?? ''}\`!`);

--- a/commands/misc.js
+++ b/commands/misc.js
@@ -58,8 +58,10 @@ function entryEmbed(row, list, ID, message) {
 			embed.addField("Reason", m.reason);
 		}
 		if(m.altLinks){
+			let altNumber = 0;
 			for(let alt in m.altLinks){
-				embed.addField(`ALTLINK: "${m.altLinks[alt]['name']}"`, m.altLinks[alt]['link'], m.altLinks.length>1);
+				altNumber = ++altNumber;
+				embed.addField(`Alt Link ${altNumber}`, `[${m.altLinks[alt]['name']}](${m.altLinks[alt]['link']})`, m.altLinks.length>1);
 			}
 		}
 		//handy little trick: boolean at the end makes it all inline if theres more than one in the field
@@ -77,14 +79,9 @@ function entryEmbed(row, list, ID, message) {
 	embed.setTimestamp(new Date().toISOString());
 	embed.setColor('#FF0625');
 
-	var str = '';
 	if ((row.tags?.length ?? 0) > 0) {
-		row.tags.forEach((e) => {
-			str += ` ${e},`;
-		});
-		str = str.replace('undefined', '');
-		str = str.substring(0, str.length - 1).trim();
-		embed.addField('Tags', str);
+		let tagString = row.tags.filter(e => e !== 'undefined').sort().join(', ');
+		embed.addField('Tags', tagString);
 	} else embed.addField('Tags', 'Not set');
 
 	return embed;

--- a/commands/misc.js
+++ b/commands/misc.js
@@ -27,11 +27,12 @@ function isUrl(s) {
  */
 function entryEmbed(row, list, ID, message) {
 	const embed = new Discord.MessageEmbed();
-	if (isUrl(row.nh)) {
-		embed.setURL(row.nh);
+	let link = row.hm ?? row.nh ?? row.eh ?? row.im;
+	if (isUrl(link)) {
+		embed.setURL(link);
 	} else {
 		if (message)
-			if (row.nh) message.channel.send(`**Warning: entry does not have a proper link of **\`${row.nh}\`.`);
+			if (link) message.channel.send(`**Warning: entry does not have a proper link of **\`${link}\`.`);
 			else message.channel.send('No results or improperly formatted row!');
 	}
 
@@ -72,7 +73,7 @@ function entryEmbed(row, list, ID, message) {
 
 
 	embed.setFooter('ID: ' + list + '#' + ID);
-	embed.setTitle(row.title ?? row.nh);
+	embed.setTitle(row.title ?? row.hm ?? row.nh ?? row.eh ?? row.im);
 	embed.setTimestamp(new Date().toISOString());
 	embed.setColor('#FF0625');
 


### PR DESCRIPTION
- Implement checks for the new link flags
- New warnings for some flags
- Fixes an edge case for entries that have an UID but an image that isn't stored on our site
- Added and changed some if statements to handle new links
- Moved the E-Hentai fetching block to prioritize it over nhentai, since their information is usually up-to-date
- Added thumbnail fetching for E-Hentai
- Changed error logging a bit to handle multiple sites
- Fixed delete command logging for new links
- Handle new links in embeds
- Use hyperlinks for alt links
- Sort tags alphabetically
- Make the -l command automatically move the link to the correct column
- Prioritize Imgur over nhentai