### PR TITLE
Fix queries, page# fetching, update error messages and add tag checks

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -456,7 +456,7 @@ function setInfo(message, list, row) {
 				const site = row?.hm?.match(/(\w+)\.io/)[1] ?? row?.nh?.match(/(\w+)\.net/)[1] ?? row?.eh?.match(/(\w+)\.org/)[1] ?? row?.im?.match(/(\w+)\.com/)[1] ?? 'some website';
 				if (e?.response?.status === 503) {
 					message.channel.send(`Failed to connect to ${site}: 503 error (likely nhentai has cloudflare up) Failed to get missing information.`);
-					console.log('Error 503: Couldn\'t connect to ${site}!');
+					console.log(`Error 503: Couldn\'t connect to ${site}!`);
 				} else {
 					message.channel.send(`Failed to get missing information from ${site}!`);
 					console.log(e);

--- a/commands/add.js
+++ b/commands/add.js
@@ -104,9 +104,10 @@ function prepUploadOperation(message, list, row) {
 		}
 
 		if (row.page === -1) {
+			let urlPage = row.eh ?? row.im ?? row.nh;
 			for (let x = 0; x < 3; x++) {
 				try {
-					row.page = await pFetch(row.nh);
+					row.page = await pFetch(urlPage);
 					if (row.page == -1) continue;
 					break;
 				} catch (e) {
@@ -454,10 +455,10 @@ function setInfo(message, list, row) {
 			} catch (e) {
 				const site = row?.hm?.match(/(\w+)\.io/)[1] ?? row?.nh?.match(/(\w+)\.net/)[1] ?? row?.eh?.match(/(\w+)\.org/)[1] ?? row?.im?.match(/(\w+)\.com/)[1] ?? 'some website';
 				if (e.response && e.response.status === 503) {
-					message.channel.send(`Failed to connect to ${site}: 503 error (likely nhentai has cloudflare up) Failed to get title and author.`);
+					message.channel.send(`Failed to connect to ${site}: 503 error (likely nhentai has cloudflare up) Failed to get missing information.`);
 					console.log('Error 503: Couldn\'t connect to ${site}!');
 				} else {
-					message.channel.send(`Failed to get title and author from ${site}!`);
+					message.channel.send(`Failed to get missing information from ${site}!`);
 					console.log(e);
 				}
 			}

--- a/commands/add.js
+++ b/commands/add.js
@@ -454,7 +454,7 @@ function setInfo(message, list, row) {
 				}
 			} catch (e) {
 				const site = row?.hm?.match(/(\w+)\.io/)[1] ?? row?.nh?.match(/(\w+)\.net/)[1] ?? row?.eh?.match(/(\w+)\.org/)[1] ?? row?.im?.match(/(\w+)\.com/)[1] ?? 'some website';
-				if (e.response && e.response.status === 503) {
+				if (e?.response?.status === 503) {
 					message.channel.send(`Failed to connect to ${site}: 503 error (likely nhentai has cloudflare up) Failed to get missing information.`);
 					console.log('Error 503: Couldn\'t connect to ${site}!');
 				} else {

--- a/commands/add.js
+++ b/commands/add.js
@@ -395,15 +395,16 @@ function setInfo(message, list, row) {
 				}
 				if (!row.parody) {
 					if (parodies.length >= 1) {
-						for (let u = 0; u < parodies.length; u++) {
+						let parodies2 = [...parodies]; //parodies will be used in the detectedCharacters block below, so we don't want to modify it
+						for (let u = 0; u < parodies2.length; u++) {
 							for (const [key, value] of Object.entries(renameParodies)) {
-								if (`${value}`.includes(parodies[u])) {
-									parodies[u] = `${key}`;
+								if (`${value}`.includes(parodies2[u])) {
+									parodies2[u] = `${key}`;
 									break;
 								}
 							}
 						}
-						let newParodies = [...new Set(parodies)];
+						let newParodies = [...new Set(parodies2)]; //removes duplicates if they exist
 						row.parody = newParodies.join(", ");
 						message.channel.send(`Updated missing parody \`${row.parody}\`!`);
 					} else {
@@ -434,7 +435,7 @@ function setInfo(message, list, row) {
 				if (detectedCharacters.length >= 1) {
 					let characterStr = "";
 					for (let i = 0; i < detectedCharacters.length; i++) {
-						characterStr += detectedCharacters[i][0];
+						characterStr += "• " + detectedCharacters[i][0].replace(/(?:^|\s+)(\w{1})/g, (letter) => letter.toUpperCase());
 						characterStr += ", aged " + detectedCharacters[i][2];
 						characterStr += ", from " + detectedCharacters[i][1];
 

--- a/commands/edit.js
+++ b/commands/edit.js
@@ -5,6 +5,7 @@ var log = require('./log');
 var misc = require('./misc');
 var sheets = require('../sheetops');
 var Jimp = require('jimp');
+var validTags = require('../config/tags.json');
 const AWS = require('aws-sdk');
 const s3 = new AWS.S3({
 	accessKeyId: info.awsId,
@@ -41,6 +42,11 @@ async function edit(message, list, ID, flags) {
 			}
 		}
 
+		//replace tildes
+		if (flags.tr?.includes('~')) {
+			flags.tr = flags.tr.replace('~', '-');
+		}
+		
 		//misc editing detected!!
 		if(flags.addalt || flags.delalt || flags.addseries || flags.delseries || flags.fav || flags.fav === null || flags.r || flags.r === null) {
 			let miscField = JSON.parse(target.misc ?? '{}');
@@ -143,6 +149,8 @@ async function edit(message, list, ID, flags) {
 				message.channel.send(
 					"**Don't edit tags in `New Finds`! Make sure it has been QCed before moving them to `Unsorted` to apply tags!**"
 				);
+			} else if (!validTags.includes(flags.atag)) {
+				message.channel.send(`**Invalid tag \`${flags.atag}\` detected!** Try capitalizing or removing unneeded characters.`);
 			} else {
 				result = target.atag(flags.atag);
 				if (result) {
@@ -150,8 +158,6 @@ async function edit(message, list, ID, flags) {
 				} else {
 					if (result === null) {
 						message.channel.send(`That tag \`${flags.atag}\` already exists on this entry. Ignoring...`);
-					} else {
-						message.channel.send('Improperly formatted tag! Try capitalizing or removing unneeded characters.');
 					}
 				}
 			}

--- a/commands/edit.js
+++ b/commands/edit.js
@@ -134,6 +134,7 @@ async function edit(message, list, ID, flags) {
 
 		target.update(r);
 		if (flags?.rtag) {
+			flags.rtag = flags.rtag.replace(/(?:^|\s+)(\w{1})/g, (letter) => letter.toUpperCase()); //make sure the tag is capitalized
 			if (list === 1) {
 				message.channel.send(
 					"**Don't edit tags in `New Finds`! Make sure it has been QCed before moving them to `Unsorted` to apply tags!**"
@@ -145,12 +146,13 @@ async function edit(message, list, ID, flags) {
 			}
 		}
 		if (flags?.atag) {
+			flags.atag = flags.atag.replace(/(?:^|\s+)(\w{1})/g, (letter) => letter.toUpperCase()); //make sure the tag is capitalized
 			if (list === 1) {
 				message.channel.send(
 					"**Don't edit tags in `New Finds`! Make sure it has been QCed before moving them to `Unsorted` to apply tags!**"
 				);
 			} else if (!validTags.includes(flags.atag)) {
-				message.channel.send(`**Invalid tag \`${flags.atag}\` detected!** Try capitalizing or removing unneeded characters.`);
+				message.channel.send(`**Invalid tag \`${flags.atag}\` detected!** Try removing unneeded characters.`);
 			} else {
 				result = target.atag(flags.atag);
 				if (result) {

--- a/commands/edit.js
+++ b/commands/edit.js
@@ -158,9 +158,7 @@ async function edit(message, list, ID, flags) {
 				if (result) {
 					message.channel.send(`Successfully added the \`${flags.atag}\` tag to entry \`${list}#${ID}\`!`);
 				} else {
-					if (result === null) {
-						message.channel.send(`That tag \`${flags.atag}\` already exists on this entry. Ignoring...`);
-					}
+					message.channel.send(`That tag \`${flags.atag}\` already exists on this entry. Ignoring...`);
 				}
 			}
 		}

--- a/commands/list.js
+++ b/commands/list.js
@@ -84,7 +84,7 @@ async function list(message, list, ID, flags) {
 					taxFraud(`\`\`\`${debt}\`\`\``);
 					debt = '';
 				}
-				debt += `${list}#${i + 1} ${check.nh} ${check.title} by ${check.author}` + '\n';
+				debt += `${list}#${i + 1} ${check.hm ?? check.nh ?? check.eh ?? check.im} ${check.title} by ${check.author}` + '\n';
 			}
 			return debt;
 		};

--- a/commands/misc.js
+++ b/commands/misc.js
@@ -4,6 +4,7 @@ var axios = require('axios').default;
 var log = require('./log');
 var info = require('../config/globalinfo.json');
 var sheets = require('../sheetops');
+var validTags = require('../config/tags.json');
 
 function update() {
 	return axios.post('https://wholesomelist.com/post', { type: 'update' });
@@ -39,7 +40,7 @@ function entryEmbed(row, list, ID, message) {
 	if (row.author) embed.setDescription('by ' + row.author);
 	else embed.setDescription('No listed author');
 
-	let linkString = `${(row.hm ? "L1 (HMarket): " + row.hm + "\n": '')}${(row.nh ? "L2 (nhentai): " + row.nh + "\n": '')}${(row.eh ? "L3 (E-Hentai): " + row.eh + "\n": '')}${(row.im ? "L1 (HMarket): " + row.im + "\n": '')}`.trim();
+	let linkString = `${(row.hm ? "L1 (HMarket): " + row.hm + "\n": '')}${(row.nh ? "L2 (nhentai): " + row.nh + "\n": '')}${(row.eh ? "L3 (E-Hentai): " + row.eh + "\n": '')}${(row.im ? "L4 (Imgur): " + row.im + "\n": '')}`.trim();
 
 	embed.addField('All Links', linkString, false);
 	embed.addField('Notes', row.note || 'None', true);
@@ -102,10 +103,11 @@ async function misc(message, cmd, bot) {
 	} else if (cmd === 'help') {
 		//oh boy
 		help(message, bot);
-
 	} else if (cmd === 'stats') {
 		//oh boy x2
 		await stats(message);
+	} else if (cmd === 'tags') {
+		tags(message);
 	}
 }
 
@@ -132,6 +134,7 @@ function help(message, bot) {
 	sauce [id] [-atag tag | -rtag tag]
 	sauce fav [id]
 	sauce stats
+	sauce tags
 	
 	Check <#611395389995876377> for more details!`;
 
@@ -268,6 +271,30 @@ async function stats(message) {
 		log.logError(message, e);
 		return false;
 	}
+}
+
+/**
+ * 
+ * @param {*} message 
+ */
+function tags(message) {
+	const embed = new Discord.MessageEmbed();
+
+	embed.setTitle('List of all tags used');
+	embed.setAuthor(
+		'Sriracha',
+		'https://cdn.discordapp.com/avatars/607661949194469376/bd5e5f7dd5885f941869200ed49e838e.png?size=256',
+		'https://wholesomelist.com'
+	);
+	embed.setDescription(validTags.map(i => '• ' + i).sort());
+	embed.setColor('#FF0625');
+	embed.setTimestamp(new Date().toISOString());
+	embed.setFooter(
+		`Vanilla God List`,
+		'https://cdn.discordapp.com/avatars/607661949194469376/bd5e5f7dd5885f941869200ed49e838e.png?size=256'
+	);
+	
+	message.channel.send(embed);
 }
 
 module.exports.update = update;

--- a/commands/page.js
+++ b/commands/page.js
@@ -12,11 +12,58 @@ var info = require('../config/globalinfo.json');
  */
 async function fetch(url) {
 	return new Promise((resolve, reject) => {
-		if (url.indexOf('nhentai') == -1 && url.indexOf('imgur') == -1 && url.indexOf("fakku") == -1) reject(-1); //not mainstream site. cannot fetch.
+		if (!url.match(/e-hentai|imgur|fakku|nhentai/)) reject(-1); //not mainstream site. cannot fetch.
 		resolve(); //continue next link of promise chain immediately
 	}).then(async () => {
-		if (url.indexOf('nhentai') > -1) {
-
+		if (url.match(/e-hentai/)) {
+			const [galleryID, galleryToken] = url.match(/\/g\/(.*?)\/(.*?)\//).slice(1);
+			const response = await axios.post('https://api.e-hentai.org/api.php',
+				{
+					"method": "gdata",
+					"gidlist": [
+						[parseInt(galleryID), galleryToken]
+					],
+					"namespace": 1
+				}
+			).then((resp) => {
+				const code = resp?.data ?? -1;
+				if (code === -1) throw code;
+				else if (code.error) throw code.error;
+				else return code;
+			});
+					
+			const data = response.gmetadata[0];		
+			page = data.filecount;
+			return page;
+		} else if (url.match(/imgur/)) {
+			let hashCode = /https:\/\/imgur.com\/a\/([A-z0-9]*)/.exec(url)[1];
+			//extract identification part from the link
+			return axios
+				.get(`https://api.imgur.com/3/album/${hashCode}`, {
+					headers: { Authorization: info.imgurClient },
+				})
+				.then((resp) => {
+					//in this case resp.data is a json because we are interacting with an API
+					code = resp.data?.data?.images_count ?? -1;
+					//fetch the info right away
+					if (code == -1) throw code;
+					else return code;
+				})
+				.catch((e) => {
+					console.log(e);
+				});
+		} else if (url.match(/fakku\.net/)) {
+			let resp = (await axios.get(url).catch((e) => {
+				console.log("Uh oh stinky");
+			}))?.data;
+			if(!resp) {
+				reject(-1);
+				return;
+			}
+			let pageNums = resp.match(/(?<num>\d+) pages/);
+			let page = +(pageNums?.groups?.num ?? -1);
+			return page;
+		} else {
 			//ensure good url
 			if (!url.match(/^https:\/\/nhentai.net\/g\/\d+/)) reject(-1);
 			if (!url.match(/https:\/\/nhentai.net\/g\/\d+\//g)) url += '/';
@@ -37,36 +84,7 @@ async function fetch(url) {
 					})[0]
 					.find('span', 'name').text
 					
-			return page
-			
-		} else if (url.match(/fakku\.net/)) {
-			let resp = (await axios.get(url).catch((e) => {
-				console.log("Uh oh stinky");
-			}))?.data;
-			if(!resp) {
-				reject(-1);
-				return;
-			}
-			let pageNums = resp.match(/(?<num>\d+) pages/);
-			let page = +(pageNums?.groups?.num ?? -1);
-			return page;
-		} else {
-			let hashCode = /https:\/\/imgur.com\/a\/([A-z0-9]*)/.exec(url)[1];
-			//extract identification part from the link
-			return axios
-				.get(`https://api.imgur.com/3/album/${hashCode}`, {
-					headers: { Authorization: info.imgurClient },
-				})
-				.then((resp) => {
-					//in this case resp.data is a json because we are interacting with an API
-					code = resp.data?.data?.images_count ?? -1;
-					//fetch the info right away
-					if (code == -1) throw code;
-					else return code;
-				})
-				.catch((e) => {
-					console.log(e);
-				});
+			return page;		
 		}
 	});
 }

--- a/commands/query.js
+++ b/commands/query.js
@@ -69,7 +69,7 @@ async function query(message, list, flags) {
 				debt = ''; //reset our string 
 			}
 			if (includes(price, accounts)) {
-				debt += `${list}#${i+1} ${check.nh} ${check.title} by ${check.author}` + '\n';
+				debt += `${list}#${i+1} ${check.hm ?? check.nh ?? check.eh ?? check.im} ${check.title} by ${check.author}` + '\n';
 				count++;
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -96,8 +96,8 @@ bot.on('message', function (message) {
 	//handle debug mode logic
 	let args = message.content.match(
 		debugMode
-			? /^(?:[Ss]aace)\s+(?<command>move|add|list|delete|feature clear|feature|random|lc|help|stats|update)?\s*(?:(?<listId>\d)(?:#(?<entryId>\d+))?(?:\s+(?<destId>\d)?)?)?\s*(?<flags>.*?)\s*$/
-			: /^(?:[Ss]auce)\s+(?<command>move|add|list|delete|feature clear|feature|random|lc|help|stats|update)?\s*(?:(?<listId>\d)(?:#(?<entryId>\d+))?(?:\s+(?<destId>\d)?)?)?\s*(?<flags>.*?)\s*$/
+			? /^(?:[Ss]aace)\s+(?<command>move|add|list|delete|feature clear|feature|random|lc|help|stats|update|tags)?\s*(?:(?<listId>\d)(?:#(?<entryId>\d+))?(?:\s+(?<destId>\d)?)?)?\s*(?<flags>.*?)\s*$/
+			: /^(?:[Ss]auce)\s+(?<command>move|add|list|delete|feature clear|feature|random|lc|help|stats|update|tags)?\s*(?:(?<listId>\d)(?:#(?<entryId>\d+))?(?:\s+(?<destId>\d)?)?)?\s*(?<flags>.*?)\s*$/
 	);
 
 	if (!args?.groups) return;
@@ -189,6 +189,7 @@ bot.on('message', function (message) {
 		case 'help':
 		case 'stats':
 		case 'update':
+		case 'tags':
 			if (validate(message, bot)) {
 				misc.misc(message, cmd, bot);
 			}


### PR DESCRIPTION
- Fixes queries when an entry doesn't have a nhentai link
- Updates page# fetching to handle new links
- Adds tags.json, which allows us to check if a tag is valid before adding it
- Also implements the tags command that displays the list
- Adds a check for the tier command
- Local thinking emoji copypasted too hard for the links display
- Changed error messages a little bit to avoid confusing FBI and made the check shorter
- Automatically capitalize tags and changed the warning a bit
- Fix parody check by making a shallow copy of the array. Also capitalize the names and change the embed message

This PR requires [tags.json](https://github.com/crispy-whiskers/sriracha/files/9438563/tags.zip) to be included in the config folder